### PR TITLE
Add gradio and pinned pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,5 @@ Shapely==1.8.4
 opencv-python
 opencv-python-headless==4.8.1.78
 openai
+gradio
+pydantic==2.10.6


### PR DESCRIPTION
## Summary
- restore original dependencies in `requirements.txt`
- add new lines for `gradio` and `pydantic` version 2.10.6

## Testing
- `pytest -q`